### PR TITLE
Add a preview page to show audience live previews

### DIFF
--- a/app/preview.html
+++ b/app/preview.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div id="preview"></div>
+        <script>
+            function showPreview() {
+                var codeWrittenInTheDark = localStorage.getItem('content');
+                document.getElementById('preview').innerHTML = codeWrittenInTheDark;
+            }
+            setInterval(showPreview, 500);
+        </script>
+    </body>
+</html>

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -92,12 +92,15 @@ gulp
       .src path.join(config.paths.assets, "**")
       .pipe gulp.dest("#{config.paths.tmp}/assets")
 
-
     instructions = gulp
       .src path.join(config.paths.app, "index.html")
       .pipe gulp.dest(config.paths.tmp)
 
-    merge assets, instructions
+    preview = gulp
+      .src path.join(config.paths.app, "preview.html")
+      .pipe gulp.dest(config.paths.tmp)
+
+    merge assets, instructions, preview
 
   .task "copy-page-files", ->
     gulp


### PR DESCRIPTION
This PR includes a `preview.html` page so that people in the audience can see what the coders are doing in a browser preview.

I didn't have time to figure out how to include the new `preview.html` page into the build/dist process (I haven't used gulp or CoffeeScript before) but if you run `gulp serve` and then open up the editor in one browser tab, and the preview page in another, you'll see live previews. It's a pretty simple hack, but effective. Enjoy!